### PR TITLE
Make shebang use env for distro compatability

### DIFF
--- a/mbtiles2osmand.py
+++ b/mbtiles2osmand.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import io
 import sqlite3
 from PIL import Image


### PR DESCRIPTION
It now for example runs on Guix System or any user environment which has python3 in `$PATH` but not in `/usr/bin`.