### PR TITLE
Add .envrc to set up developer environment

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use guix --ad-hoc python python-pillow


### PR DESCRIPTION
This is just a small helper thing for developers, but if they have Direnv and Guix installed this file will automatically start a developer environment with all the dependencies of this project when the user enters the directory with their shell. Perhaps the most useful thing is that there now exists an explicit dependency list.