### PR TITLE
Create function to operate this from outside (with import)

### DIFF
--- a/mbtiles2osmand.py
+++ b/mbtiles2osmand.py
@@ -2,33 +2,7 @@
 import io
 import sqlite3
 from PIL import Image
-import argparse
 import os
-
-parser = argparse.ArgumentParser(
-    description="Converts mbtiles format to sqlitedb format suitable for OsmAnd"
-)
-
-parser.add_argument("input", help="input file")
-parser.add_argument("output", help="output file")
-parser.add_argument(
-    "-f", "-force", action="store_true", help="override output file if exists"
-)
-parser.add_argument(
-    "--jpg",
-    dest="jpeg_quality",
-    action="store",
-    help="convert tiles to JPEG with specified quality",
-)
-args = parser.parse_args()
-
-if os.path.isfile(args.output):
-    if args.f:
-        os.remove(args.output)
-    else:
-        print("Output file already exists. Add -f option for overwrite")
-        exit(1)
-
 
 # See:
 # * https://github.com/osmandapp/Osmand/blob/master/OsmAnd/src/net/osmand/plus/SQLiteTileSource.java
@@ -42,34 +16,77 @@ def to_jpg(raw_bytes, quality):
     return stream.getvalue()
 
 
-source = sqlite3.connect(args.input)
-dest = sqlite3.connect(args.output)
-
-
-scur = source.cursor()
-dcur = dest.cursor()
-
-dcur.execute(
-    """CREATE TABLE tiles (x int, y int, z int, s int, image blob, PRIMARY KEY (x,y,z,s));"""
-)
-dcur.execute("""CREATE TABLE info (maxzoom Int, minzoom Int);""")
-
-for row in scur.execute(
-    "SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles"
+# Converts mbtiles format to sqlitedb format suitable for OsmAnd
+# force_overwrite : override output file if exists
+# jpeg_quality : 'convert tiles to JPEG with specified quality'
+def mbtiles2osmand_convertion(
+    intput_file, output_file, force_overwrite=False, jpeg_quality=None
 ):
-    image = row[3]
-    if args.jpeg_quality != None:
-        image = to_jpg(image, int(args.jpeg_quality))
-    z, x, y, s = int(row[0]), int(row[1]), int(row[2]), 0
-    y = 2**z - 1 - y
-    z = 17 - z
+    if os.path.isfile(output_file):
+        if force_overwrite:
+            os.remove(output_file)
+        else:
+            print("Output file already exists. Add -f option for overwrite")
+            exit(1)
+    source = sqlite3.connect(intput_file)
+    dest = sqlite3.connect(output_file)
+
+    scur = source.cursor()
+    dcur = dest.cursor()
+
     dcur.execute(
-        "INSERT INTO tiles (x, y, z, s, image) VALUES (?, ?, ?, ?, ?)",
-        [x, y, z, s, sqlite3.Binary(image)],
+        """CREATE TABLE tiles (x int, y int, z int, s int, image blob, PRIMARY KEY (x,y,z,s));"""
+    )
+    dcur.execute("""CREATE TABLE info (maxzoom Int, minzoom Int);""")
+
+    for row in scur.execute(
+        "SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles"
+    ):
+        image = row[3]
+        if jpeg_quality != None:
+            image = to_jpg(image, int(jpeg_quality))
+        z, x, y, s = int(row[0]), int(row[1]), int(row[2]), 0
+        y = 2**z - 1 - y
+        z = 17 - z
+        dcur.execute(
+            "INSERT INTO tiles (x, y, z, s, image) VALUES (?, ?, ?, ?, ?)",
+            [x, y, z, s, sqlite3.Binary(image)],
+        )
+
+    dcur.execute("INSERT INTO info (maxzoom, minzoom) SELECT max(z),min(z) from tiles")
+
+    dest.commit()
+    source.close()
+    dest.close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Converts mbtiles format to sqlitedb format suitable for OsmAnd"
     )
 
-dcur.execute("INSERT INTO info (maxzoom, minzoom) SELECT max(z),min(z) from tiles")
+    parser.add_argument("input", help="input file")
+    parser.add_argument("output", help="output file")
+    parser.add_argument(
+        "-f", "-force", action="store_true", help="override output file if exists"
+    )
+    parser.add_argument(
+        "--jpg",
+        dest="jpeg_quality",
+        action="store",
+        help="convert tiles to JPEG with specified quality",
+    )
+    args = parser.parse_args()
 
-dest.commit()
-source.close()
-dest.close()
+    if os.path.isfile(args.output):
+        if args.f:
+            os.remove(args.output)
+        else:
+            print("Output file already exists. Add -f option for overwrite")
+            exit(1)
+
+    mbtiles2osmand_convertion(
+        args.input, args.output, force_overwrite=args.f, jpeg_quality=args.jpeg_quality
+    )

--- a/mbtiles2osmand.py
+++ b/mbtiles2osmand.py
@@ -5,12 +5,21 @@ from PIL import Image
 import argparse
 import os
 
-parser = argparse.ArgumentParser(description='Converts mbtiles format to sqlitedb format suitable for OsmAnd')
+parser = argparse.ArgumentParser(
+    description="Converts mbtiles format to sqlitedb format suitable for OsmAnd"
+)
 
-parser.add_argument('input', help='input file')
-parser.add_argument('output', help='output file')
-parser.add_argument('-f', '-force', action='store_true', help='override output file if exists')
-parser.add_argument('--jpg', dest='jpeg_quality', action='store', help='convert tiles to JPEG with specified quality')
+parser.add_argument("input", help="input file")
+parser.add_argument("output", help="output file")
+parser.add_argument(
+    "-f", "-force", action="store_true", help="override output file if exists"
+)
+parser.add_argument(
+    "--jpg",
+    dest="jpeg_quality",
+    action="store",
+    help="convert tiles to JPEG with specified quality",
+)
 args = parser.parse_args()
 
 if os.path.isfile(args.output):
@@ -27,10 +36,11 @@ if os.path.isfile(args.output):
 
 def to_jpg(raw_bytes, quality):
     im = Image.open(io.BytesIO(raw_bytes))
-    im = im.convert('RGB')
+    im = im.convert("RGB")
     stream = io.BytesIO()
-    im.save(stream, format = "JPEG", subsampling=0, quality=quality)
+    im.save(stream, format="JPEG", subsampling=0, quality=quality)
     return stream.getvalue()
+
 
 source = sqlite3.connect(args.input)
 dest = sqlite3.connect(args.output)
@@ -39,21 +49,27 @@ dest = sqlite3.connect(args.output)
 scur = source.cursor()
 dcur = dest.cursor()
 
-dcur.execute('''CREATE TABLE tiles (x int, y int, z int, s int, image blob, PRIMARY KEY (x,y,z,s));''')
-dcur.execute('''CREATE TABLE info (maxzoom Int, minzoom Int);''')
+dcur.execute(
+    """CREATE TABLE tiles (x int, y int, z int, s int, image blob, PRIMARY KEY (x,y,z,s));"""
+)
+dcur.execute("""CREATE TABLE info (maxzoom Int, minzoom Int);""")
 
-for row in scur.execute("SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles"):
+for row in scur.execute(
+    "SELECT zoom_level, tile_column, tile_row, tile_data FROM tiles"
+):
     image = row[3]
-    if(args.jpeg_quality != None):
+    if args.jpeg_quality != None:
         image = to_jpg(image, int(args.jpeg_quality))
     z, x, y, s = int(row[0]), int(row[1]), int(row[2]), 0
-    y = 2 ** z - 1 - y
+    y = 2**z - 1 - y
     z = 17 - z
-    dcur.execute("INSERT INTO tiles (x, y, z, s, image) VALUES (?, ?, ?, ?, ?)", [x, y, z, s, sqlite3.Binary(image)])
+    dcur.execute(
+        "INSERT INTO tiles (x, y, z, s, image) VALUES (?, ?, ?, ?, ?)",
+        [x, y, z, s, sqlite3.Binary(image)],
+    )
 
 dcur.execute("INSERT INTO info (maxzoom, minzoom) SELECT max(z),min(z) from tiles")
 
 dest.commit()
 source.close()
 dest.close()
-


### PR DESCRIPTION
This is to support outside sourcing the file.

Like that we can do
```
from mbtiles2osmand import mbtiles2osmand_convertion

mbtiles2osmand_convertion("input.mbtiles", "output.sqlite", force_overwrite=True)
```

from another python script